### PR TITLE
Feat: Add NZXT RGB & Fan Controller V2 and Smart Device V2 (USB PID 0x2019)

### DIFF
--- a/src/libs/Controller/USBController.cs
+++ b/src/libs/Controller/USBController.cs
@@ -37,8 +37,11 @@ namespace FanCtrl
         // EVGA CLC
         CLC = 0xb200,
 
-        // NZXT RGB & Fan Controller
+        // NZXT RGB & Fan Controller V1
         RGBAndFanController = 0x2009,
+
+        // NZXT RGB & Fan Controller V2 / Smart Device V2
+        RGBAndFanControllerV2 = 0x2019,
     }
 
     public class USBController

--- a/src/libs/Hardware/HardwareManager.cs
+++ b/src/libs/Hardware/HardwareManager.cs
@@ -516,26 +516,36 @@ namespace FanCtrl
                     var fanDevice = new HardwareDevice("NZXT RGB & Fan Controller");
                     var controlDevice = new HardwareDevice("NZXT RGB & Fan Controller");
                     uint num = 1;
-                    uint devCount = HidUSBController.getDeviceCount(USBVendorID.NZXT, USBProductID.RGBAndFanController);
-                    for (uint i = 0; i < devCount; i++)
+
+                    // Support both V1 (0x2009) and V2 (0x2019) RGB & Fan Controllers
+                    USBProductID[] supportedProductIDs = { 
+                        USBProductID.RGBAndFanController,     // V1 device
+                        USBProductID.RGBAndFanControllerV2    // V2 / Smart Device V2
+                    };
+
+                    foreach (var productID in supportedProductIDs)
                     {
-                        var rgb = new RGBnFC();
-                        if (rgb.start(i) == true)
+                        uint devCount = HidUSBController.getDeviceCount(USBVendorID.NZXT, productID);
+                        for (uint i = 0; i < devCount; i++)
                         {
-                            RGBnFCList.Add(rgb);
-
-                            for (int j = 0; j < RGBnFC.MAX_FAN_COUNT; j++)
+                            var rgb = new RGBnFC();
+                            if (rgb.start(i, productID) == true)
                             {
-                                var id = string.Format("NZXT/RGBnFC/{0}/Fan/{1}", i, j);
-                                var fan = new RGBnFCFanSpeed(id, rgb, j, num);
-                                fanDevice.addDevice(fan);
+                                RGBnFCList.Add(rgb);
 
-                                id = string.Format("NZXT/RGBnFC/{0}/Control/{1}", i, j);
-                                var control = new RGBnFCControl(id, rgb, j, num);
-                                controlDevice.addDevice(control);
-                                this.addChangeValue(control.getMinSpeed(), control, false);
+                                for (int j = 0; j < RGBnFC.MAX_FAN_COUNT; j++)
+                                {
+                                    var id = string.Format("NZXT/RGBnFC/{0}/Fan/{1}", i, j);
+                                    var fan = new RGBnFCFanSpeed(id, rgb, j, num);
+                                    fanDevice.addDevice(fan);
 
-                                num++;
+                                    id = string.Format("NZXT/RGBnFC/{0}/Control/{1}", i, j);
+                                    var control = new RGBnFCControl(id, rgb, j, num);
+                                    controlDevice.addDevice(control);
+                                    this.addChangeValue(control.getMinSpeed(), control, false);
+
+                                    num++;
+                                }
                             }
                         }
                     }

--- a/src/libs/Hardware/RGBnFC.cs
+++ b/src/libs/Hardware/RGBnFC.cs
@@ -33,7 +33,7 @@ namespace FanCtrl
             }
         }
 
-        public bool start(uint index)
+        public bool start(uint index, USBProductID productID)
         {
             Monitor.Enter(mLock);
 
@@ -46,7 +46,8 @@ namespace FanCtrl
                 mFileName = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + "\\" + string.Format("RGBnFC{0}.json", index + 1);
             }
 
-            mUSBController = new HidUSBController(USBVendorID.NZXT, USBProductID.RGBAndFanController);
+            // Support both V1 (0x2009) and V2 (0x2019) devices
+            mUSBController = new HidUSBController(USBVendorID.NZXT, productID);
             mUSBController.onRecvHandler += onRecv;
             if (mUSBController.start(index) == false)
             {


### PR DESCRIPTION
### **Summary**
Adds support for NZXT V2 controllers by implementing dynamic product ID detection instead of hardcoded V1-only support.

Fixes #80

**Supported devices:**
- ✅ RGB & Fan Controller V1 (0x2009) - existing support maintained
- ✅ RGB & Fan Controller V2 (0x2019) - newly supported
- ✅ Smart Device V2 (0x2019) - newly supported

### **Changes**
- **USBController.cs**: Added `RGBAndFanControllerV2 = 0x2019` enum value with comment "V2 / Smart Device V2"
- **HardwareManager.cs**: Updated device enumeration to support both V1 and V2 product IDs using array-based detection
- **RGBnFC.cs**: Modified constructor to accept dynamic `productID` parameter instead of hardcoded V1 ID

### **Implementation Details**
- Replaced hardcoded `USBProductID.RGBAndFanController` with dynamic `productID` parameter
- Added `supportedProductIDs` array containing both V1 and V2 device IDs
- Maintained backward compatibility - existing V1 devices continue working unchanged

**Files changed**: 3 files
**Breaking changes**: None